### PR TITLE
fix: allow definition of functions in global scope

### DIFF
--- a/lib/puppet-lint/plugins/check_global_definition.rb
+++ b/lib/puppet-lint/plugins/check_global_definition.rb
@@ -2,7 +2,7 @@ module PuppetLintGlobalDefinionCheck
   private
 
   def check_for_global_token(type, value = nil)
-    global_tokens.each_with_index do |token, i|
+    global_tokens.each do |token|
       next unless token.type == type
       next unless value.nil? || token.value == value
 

--- a/lib/puppet-lint/plugins/check_global_definition.rb
+++ b/lib/puppet-lint/plugins/check_global_definition.rb
@@ -1,12 +1,12 @@
 module PuppetLintGlobalDefinionCheck
   private
 
-  def check_for_global_token(type, value = nil)
+  def check_for_global_token(type)
     global_tokens.each do |token|
       next unless token.type == type
-      next unless value.nil? || token.value == value
 
-      message = value.nil? ? token.value : "#{token.value} #{token.next_code_token.value}"
+      message = yield(token)
+      next unless message
 
       notify :error,
         message: "definition #{message} in global space",
@@ -37,7 +37,9 @@ PuppetLint.new_check(:global_resource) do
 
   def check
     check_for_global_resources
-    check_for_global_token(:NAME, "include")
+    check_for_global_token(:NAME) do |token|
+      "#{token.value} #{token.next_code_token.value}" if token.value == "include"
+    end
   end
 
   def check_for_global_resources
@@ -56,6 +58,8 @@ PuppetLint.new_check(:global_function) do
   include PuppetLintGlobalDefinionCheck
 
   def check
-    check_for_global_token(:FUNCTION_NAME)
+    check_for_global_token(:FUNCTION_NAME) do |token|
+        "#{token.value} #{token.next_code_token.value}" unless !token.prev_code_token.nil? && token.prev_code_token.type == :FUNCTION
+    end
   end
 end

--- a/spec/puppet-lint/plugins/check_global_function_spec.rb
+++ b/spec/puppet-lint/plugins/check_global_function_spec.rb
@@ -30,4 +30,26 @@ describe "global_function" do
       expect(problems).to have(1).problems
     end
   end
+
+  context "module function definition" do
+    let(:code) do
+      <<-EOS
+      # @summary function to clean hash of undef and empty values
+      function nine_networkinterfaces::delete_empty_values(
+        Hash $hash,
+      ) >> Hash {
+        $hash.filter |$key, $value| {
+          case $value {
+            Collection: { $value =~ NotUndef and !$value.empty }
+            default:    { $value =~ NotUndef }
+          }
+        }
+      }
+      EOS
+    end
+
+    it "should not detect any problems" do
+      expect(problems).to have(0).problems
+    end
+  end
 end


### PR DESCRIPTION
Modules define functions in the global scope. This should not be marked as linter issue.