### PR TITLE
fix: ignore resources and function calls in custom function definitions

### DIFF
--- a/lib/puppet-lint/plugins/check_global_definition.rb
+++ b/lib/puppet-lint/plugins/check_global_definition.rb
@@ -16,19 +16,19 @@ module PuppetLintGlobalDefinionCheck
   end
 
   def global_tokens
-    @global_tokens ||= tokens.reject.with_index { |_, i| secure_ranges.any? { |s| s[0] < i && s[1] > i } }
+    @global_tokens ||= tokens.reject.with_index { |_, i| safe_ranges.any? { |s| s[0] < i && s[1] > i } }
   end
 
-  def secure_ranges
-    return @secure_ranges if @secure_ranges
+  def safe_ranges
+    return @safe_ranges if @safe_ranges
 
-    @secure_ranges = []
+    @safe_ranges = []
 
-    class_indexes.each { |c| @secure_ranges << [c[:start], c[:end]] }
-    defined_type_indexes.each { |d| @secure_ranges << [d[:start], d[:end]] }
-    node_indexes.each { |n| @secure_ranges << [n[:start], n[:end]] }
+    class_indexes.each { |c| @safe_ranges << [c[:start], c[:end]] }
+    defined_type_indexes.each { |d| @safe_ranges << [d[:start], d[:end]] }
+    node_indexes.each { |n| @safe_ranges << [n[:start], n[:end]] }
 
-    @secure_ranges
+    @safe_ranges
   end
 end
 
@@ -44,7 +44,7 @@ PuppetLint.new_check(:global_resource) do
 
   def check_for_global_resources
     resource_indexes.each do |r|
-      next if secure_ranges.any? { |s| s[0] < r[:start] && s[1] > r[:end] }
+      next if safe_ranges.any? { |s| s[0] < r[:start] && s[1] > r[:end] }
 
       notify :error,
         message: "resource #{r[:type].value} in global space",

--- a/lib/puppet-lint/plugins/check_global_definition.rb
+++ b/lib/puppet-lint/plugins/check_global_definition.rb
@@ -19,6 +19,49 @@ module PuppetLintGlobalDefinionCheck
     @global_tokens ||= tokens.reject.with_index { |_, i| safe_ranges.any? { |s| s[0] < i && s[1] > i } }
   end
 
+  def custom_functions_indexes
+    # Code adapted from https://github.com/puppetlabs/puppet-lint/blob/dcff4a1b8d3bf5c15762db826967dd03200626be/lib/puppet-lint/data.rb#L298
+    type = :FUNCTION
+    result = []
+    tokens.each_with_index do |token, i|
+      next unless token.type == type
+
+      brace_depth = 0
+      paren_depth = 0
+      in_params = false
+      return_type = nil
+      tokens[i + 1..-1].each_with_index do |definition_token, j|
+        case definition_token.type
+        when :LPAREN
+          in_params = true if paren_depth.zero? && brace_depth.zero?
+          paren_depth += 1
+        when :RPAREN
+          in_params = false if paren_depth == 1 && brace_depth.zero?
+          paren_depth -= 1
+        when :RSHIFT
+          return_type = definition_token.next_code_token unless definition_token.next_code_token.nil? || definition_token.next_code_token.type != :TYPE
+        when :LBRACE
+          brace_depth += 1
+        when :RBRACE
+          brace_depth -= 1
+          if brace_depth.zero? && !in_params && (token.next_code_token.type != :LBRACE)
+            result << {
+              start: i,
+              end: i + j + 1,
+              tokens: tokens[i..(i + j + 1)],
+              param_tokens: PuppetLint::Data.param_tokens(tokens[i..(i + j + 1)]),
+              type: type,
+              name_token: token.next_code_token,
+              return_type: return_type
+            }
+            break
+          end
+        end
+      end
+    end
+    result
+  end
+
   def safe_ranges
     return @safe_ranges if @safe_ranges
 
@@ -27,6 +70,7 @@ module PuppetLintGlobalDefinionCheck
     class_indexes.each { |c| @safe_ranges << [c[:start], c[:end]] }
     defined_type_indexes.each { |d| @safe_ranges << [d[:start], d[:end]] }
     node_indexes.each { |n| @safe_ranges << [n[:start], n[:end]] }
+    custom_functions_indexes.each { |cf| @safe_ranges << [cf[:start], cf[:end]] }
 
     @safe_ranges
   end
@@ -59,7 +103,7 @@ PuppetLint.new_check(:global_function) do
 
   def check
     check_for_global_token(:FUNCTION_NAME) do |token|
-      "function call #{token.value}(...)" unless !token.prev_code_token.nil? && token.prev_code_token.type == :FUNCTION
+      "function call #{token.value}(...)"
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_global_definition.rb
+++ b/lib/puppet-lint/plugins/check_global_definition.rb
@@ -9,7 +9,7 @@ module PuppetLintGlobalDefinionCheck
       next unless message
 
       notify :error,
-        message: "definition #{message} in global space",
+        message: "#{message} in global space",
         line: token.line,
         column: token.column
     end
@@ -59,7 +59,7 @@ PuppetLint.new_check(:global_function) do
 
   def check
     check_for_global_token(:FUNCTION_NAME) do |token|
-        "#{token.value} #{token.next_code_token.value}" unless !token.prev_code_token.nil? && token.prev_code_token.type == :FUNCTION
+      "function call #{token.value}(...)" unless !token.prev_code_token.nil? && token.prev_code_token.type == :FUNCTION
     end
   end
 end

--- a/puppet-lint-global_definition-check.gemspec
+++ b/puppet-lint-global_definition-check.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     Extends puppet-lint to ensure that your manifests have no global resources.
   EOF
 
-  spec.add_dependency "puppet-lint", "~> 2.1"
+  spec.add_dependency "puppet-lint", ">= 2.2", "< 5"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rspec-its", "~> 1.3"
   spec.add_development_dependency "rspec-collection_matchers", "~> 1.2"

--- a/spec/puppet-lint/plugins/check_global_function_spec.rb
+++ b/spec/puppet-lint/plugins/check_global_function_spec.rb
@@ -11,7 +11,7 @@ describe "global_function" do
     end
 
     it "should not detect any problems" do
-      expect(problems).to have(0).problems
+      expect(problems.size).to eq(0)
     end
   end
 
@@ -27,7 +27,7 @@ describe "global_function" do
     end
 
     it "should detect a problem" do
-      expect(problems).to have(1).problems
+      expect(problems.size).to eq(1)
     end
   end
 
@@ -49,7 +49,7 @@ describe "global_function" do
     end
 
     it "should not detect any problems" do
-      expect(problems).to have(0).problems
+      expect(problems.size).to eq(0)
     end
   end
 end

--- a/spec/puppet-lint/plugins/check_global_function_spec.rb
+++ b/spec/puppet-lint/plugins/check_global_function_spec.rb
@@ -31,19 +31,11 @@ describe "global_function" do
     end
   end
 
-  context "module function definition" do
+  context "custom function definition with function call" do
     let(:code) do
       <<-EOS
-      # @summary function to clean hash of undef and empty values
-      function nine_networkinterfaces::delete_empty_values(
-        Hash $hash,
-      ) >> Hash {
-        $hash.filter |$key, $value| {
-          case $value {
-            Collection: { $value =~ NotUndef and !$value.empty }
-            default:    { $value =~ NotUndef }
-          }
-        }
+      function test_module::test_function() >> Any {
+        function_call()
       }
       EOS
     end

--- a/spec/puppet-lint/plugins/check_global_resource_spec.rb
+++ b/spec/puppet-lint/plugins/check_global_resource_spec.rb
@@ -5,7 +5,7 @@ describe "global_resource" do
     let(:code) { "class test { file { 'file': } }" }
 
     it "should not detect any problems" do
-      expect(problems).to have(0).problems
+      expect(problems.size).to eq(0)
     end
   end
 
@@ -13,7 +13,7 @@ describe "global_resource" do
     let(:code) { "define test ($param = undef) { file { 'file': } }" }
 
     it "should not detect any problems" do
-      expect(problems).to have(0).problems
+      expect(problems.size).to eq(0)
     end
   end
 
@@ -21,7 +21,7 @@ describe "global_resource" do
     let(:code) { "node 'test' { file { 'file': } }" }
 
     it "should not detect any problems" do
-      expect(problems).to have(0).problems
+      expect(problems.size).to eq(0)
     end
   end
 
@@ -31,7 +31,7 @@ describe "global_resource" do
     end
 
     it "should detect a problem" do
-      expect(problems).to have(1).problems
+      expect(problems.size).to eq(1)
     end
   end
 
@@ -39,7 +39,7 @@ describe "global_resource" do
     let(:code) { "class test { file { 'file': } } \ninclude testclass" }
 
     it "should detect a problem" do
-      expect(problems).to have(1).problems
+      expect(problems.size).to eq(1)
     end
   end
 
@@ -53,7 +53,7 @@ describe "global_resource" do
     end
 
     it "should not detect any problems" do
-      expect(problems).to have(0).problems
+      expect(problems.size).to eq(0)
     end
   end
 end


### PR DESCRIPTION
The former implementation would report function calls within custom function definitions. This PR declares custom function definitions as safe range and will therefore be excluded from global token checks.